### PR TITLE
Feature/conda 3 and pypy35v6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,17 @@ install:
       conda install --yes --quiet conda-forge-ci-setup=1
       source run_conda_forge_build_setup
 
-script:
-  - conda build ./recipe -m ./.ci_support/${CONFIG}.yaml
 
-  - upload_or_check_non_existence ./recipe conda-forge --channel=main -m ./.ci_support/${CONFIG}.yaml
+cache: bundler
+
+jobs:
+  include:
+    - stage: prepare cache
+      script:
+        - conda build ./recipe -m ./.ci_support/${CONFIG}.yaml --check
+
+    - stage: build
+      script:
+        - conda build ./recipe -m ./.ci_support/${CONFIG}.yaml
+
+        - upload_or_check_non_existence ./recipe conda-forge --channel=main -m ./.ci_support/${CONFIG}.yaml

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,7 @@ jobs:
   include:
     - stage: prepare cache
       script:
-        - conda build ./recipe -m ./.ci_support/${CONFIG}.yaml --check
+        - conda build ./recipe -m ./.ci_support/${CONFIG}.yaml --source
 
     - stage: build
       script:

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -4,17 +4,11 @@ export LDFLAGS="-L${PREFIX}/lib"
 export CFLAGS="-I${PREFIX}/include"
 export PKG_CONFIG_PATH="$PREFIX/lib/pkgconfig"
 
-PYPY3_SRC_DIR=$SRC_DIR
+PYPY3_SRC_DIR=$SRC_DIR/pypy3
 
 if [ $(uname) == Darwin ]; then
-    # We must use pypy2 to build (which is faster), otherwise the build might timeout.
-    curl -L https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.9.0-osx64.tar.bz2 -O
-    echo "94de50ed80c7f6392ed356c03fd54cdc84858df43ad21e9e971d1b6da0f6b867 *pypy2-v5.9.0-osx64.tar.bz2" | shasum -a 256 -c -
-
-    tar -xvf pypy2-v5.9.0-osx64.tar.bz2
-
     export CC=clang
-    export PYTHON=$SRC_DIR/pypy2-v5.9.0-osx64/bin/pypy
+    export PYTHON=$SRC_DIR/pypy2-osx/bin/pypy
     export N_JOBS=2
 
     # libffi doesn't look in the correct location. We modify a copy of it since it's a hard link to conda's file.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,7 @@ source:
 
 build:
   number: 0
-  skip: True  # [win]
+  skip: True  # [not osx]
   skip_compile_pyc:
     - lib*
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,9 +13,9 @@ source:
     patches:
       - tklib_build.patch
 
-  - url: https://bitbucket.org/pypy/pypy/downloads/pypy2-v6.0.0-osx64.tar.bz2  # [osx]
-    fn: pypy2-v6.0.0-osx64.tar.bz2  # [osx]
-    sha256: d7dc443e6bb9a45212e8d8f5a63e9f6ce23f1d88c50709efea1c75b76c8bc186  # [osx]
+  - url: https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.9.0-osx64.tar.bz2  # [osx]
+    fn: pypy2-v5.9.0-osx64.tar.bz2  # [osx]
+    sha256: 94de50ed80c7f6392ed356c03fd54cdc84858df43ad21e9e971d1b6da0f6b867  # [osx]
     folder: pypy2-osx  # [osx]
 
 build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,7 +40,7 @@ requirements:
     - zlib
     - bzip2
     - expat
-    - ncurses
+    - ncurses >=6.0
     - gdbm
     - xz
     - tk
@@ -52,7 +52,7 @@ requirements:
     - tk
     - zlib
     - bzip2
-    - ncurses
+    - ncurses >=6.0
     - gdbm
     - xz
     - expat

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
       - tklib_build.patch
 
   - url: https://bitbucket.org/pypy/pypy/downloads/pypy2-v6.0.0-osx64.tar.bz2  # [osx]
-    fn: ppypy2-v6.0.0-osx64.tar.bz2  # [osx]
+    fn: pypy2-v6.0.0-osx64.tar.bz2  # [osx]
     sha256: d7dc443e6bb9a45212e8d8f5a63e9f6ce23f1d88c50709efea1c75b76c8bc186  # [osx]
     folder: pypy2-osx  # [osx]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,11 +6,17 @@ package:
   version: {{ version }}
 
 source:
-  url: https://bitbucket.org/pypy/pypy/downloads/pypy3-v{{ version }}-src.tar.bz2
-  fn: pypy3-v{{ version }}-src.tar.bz2
-  sha256: f5548e06e2fc0c24ec8b6e3c5b09f90081818f7caa3e436dc312592611724713
-  patches:
-    - tklib_build.patch
+  - url: https://bitbucket.org/pypy/pypy/downloads/pypy3-v{{ version }}-src.tar.bz2
+    fn: pypy3-v{{ version }}-src.tar.bz2
+    sha256: f5548e06e2fc0c24ec8b6e3c5b09f90081818f7caa3e436dc312592611724713
+    folder: pypy3
+    patches:
+      - tklib_build.patch
+
+  - url: https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.9.0-osx64.tar.bz2  # [osx]
+    fn: pypy2-v5.9.0-osx64.tar.bz2  # [osx]
+    sha256: 94de50ed80c7f6392ed356c03fd54cdc84858df43ad21e9e971d1b6da0f6b867  # [osx]
+    folder: pypy2-osx  # [osx]
 
 build:
   number: 0
@@ -59,7 +65,7 @@ about:
     home: http://pypy.org/
     license: MIT
     license_family: MIT
-    license_file: LICENSE
+    license_file: pypy3/LICENSE
     summary: PyPy is a Python interpreter and just-in-time compiler.
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pypy3.5" %}
-{% set version = "5.10.1" %}
+{% set version = "6.0.0" %}
 
 package:
   name: {{ name }}
@@ -8,14 +8,14 @@ package:
 source:
   - url: https://bitbucket.org/pypy/pypy/downloads/pypy3-v{{ version }}-src.tar.bz2
     fn: pypy3-v{{ version }}-src.tar.bz2
-    sha256: f5548e06e2fc0c24ec8b6e3c5b09f90081818f7caa3e436dc312592611724713
+    sha256: ed8005202b46d6fc6831df1d13a4613bc40084bfa42f275068edadf8954034a3
     folder: pypy3
     patches:
       - tklib_build.patch
 
-  - url: https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.9.0-osx64.tar.bz2  # [osx]
-    fn: pypy2-v5.9.0-osx64.tar.bz2  # [osx]
-    sha256: 94de50ed80c7f6392ed356c03fd54cdc84858df43ad21e9e971d1b6da0f6b867  # [osx]
+  - url: https://bitbucket.org/pypy/pypy/downloads/pypy2-v6.0.0-osx64.tar.bz2  # [osx]
+    fn: ppypy2-v6.0.0-osx64.tar.bz2  # [osx]
+    sha256: d7dc443e6bb9a45212e8d8f5a63e9f6ce23f1d88c50709efea1c75b76c8bc186  # [osx]
     folder: pypy2-osx  # [osx]
 
 build:


### PR DESCRIPTION
Updating the recipe to to pypy3.5 v6.0.0, and using conda-build 3 features.
pypy2.7 v6 is also used for building under OSX, hopefully to get a slightly faster build.

Checklist
* [x] Used a fork of the feedstock to propose changes
* [ ] ~Bumped the build number (if the version is unchanged)~
* [x] Reset the build number to `0` (if the version changed)
* [ ] ~[Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy`~
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

Closes #2


<!--
Please add any other relevant info below:
-->
